### PR TITLE
Try to get casadata installed first

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,12 @@
 name: Github Pages
 
 on:
-  push:
-    branches:
-      - master
-    # paths:
-    #    - 'spectral_fitting/*.ipynb'
-    #    - '*.json'
-    #    - '.github/**'
+  issues:
+    types:
+    - opened
+  pull_request_target:
+    types:
+    - opened
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,62 @@
+name: Github Pages
+
+on:
+  push:
+    branches:
+      - master
+    # paths:
+    #    - 'spectral_fitting/*.ipynb'
+    #    - '*.json'
+    #    - '.github/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up python
+        id: setup-python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      - name: Install requirements
+        run: pip install -r requirements.txt
+
+      - name: Export notebooks
+        run: |
+            JUPYTER_CONFIG_DIR=./.jupyter jupyter nbconvert spectral_fitting/*.ipynb --execute --to html --ExecutePreprocessor.kernel_name=python
+            JUPYTER_CONFIG_DIR=./.jupyter jupyter nbconvert casa_to_spectralcube_guide/*.ipynb --execute --to html --ExecutePreprocessor.kernel_name=python
+            JUPYTER_CONFIG_DIR=./.jupyter jupyter nbconvert masking_and_moments/*.ipynb --execute --to html --ExecutePreprocessor.kernel_name=python
+            JUPYTER_CONFIG_DIR=./.jupyter jupyter nbconvert parallel_spectral_fitting/*.ipynb --execute --to html --ExecutePreprocessor.kernel_name=python
+            JUPYTER_CONFIG_DIR=./.jupyter jupyter nbconvert DameCube.ipynb --execute --to html --ExecutePreprocessor.kernel_name=python
+            JUPYTER_CONFIG_DIR=./.jupyter jupyter nbconvert PVDiagramPlotting.ipynb --execute --to html --ExecutePreprocessor.kernel_name=python
+            JUPYTER_CONFIG_DIR=./.jupyter jupyter nbconvert DiskPVExample.ipynb --execute --to html --ExecutePreprocessor.kernel_name=python
+            # JUPYTER_CONFIG_DIR=./.jupyter jupyter nbconvert SpectralCubeReprojectExample.ipynb --execute --to html --ExecutePreprocessor.kernel_name=python
+            # JUPYTER_CONFIG_DIR=./.jupyter jupyter nbconvert SpectralCubeReprojectMaskExample_v4p1.ipynb.ipynb --execute --to html --ExecutePreprocessor.kerne]l_name=python
+
+      - name: Prepare public folder
+        id: folder
+        run: |
+          cp spectral_fitting/*.html docs
+          cp casa_to_spectralcube_guide/*.html docs
+          cp masking_and_moments/*.html docs
+          cp parallel_spectral_fitting/*.html docs
+          cp *.html docs
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: docs
+          destination: docs/_site
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: docs

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ git+https://github.com/radio-astro-tools/radio-beam/#egg=radio-beam
 git+https://github.com/radio-astro-tools/pvextractor/#egg=pvextractor
 dask[complete]
 dask-image
+casadata
 casatools
 casatasks
-casadata


### PR DESCRIPTION
Installing casatools/casatasks failed with:
```python
AutoUpdatesNotAllowed: data_update: path must exist as a directory and it must be owned by the user, path = /home/runner/.casa/data
```
so maybe if we put `casadata` earlier in the install path it won't try to update?